### PR TITLE
fixes slug bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,8 @@ end
 # heroku gems
 gem 'rails_12factor', group: :production
 
-# hound gems
-gem 'rubocop', '~> 0.47.1', require: false
+# friendly id gems
+gem 'friendly_id', '~> 5.1.0'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
-    ast (2.3.0)
     autoprefixer-rails (6.7.5)
       execjs
     bcrypt (3.1.11)
@@ -73,6 +72,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.17)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.8.0)
@@ -109,10 +110,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
-    parser (2.4.0.0)
-      ast (~> 2.2)
     pg (0.19.0)
-    powerpack (0.1.1)
     public_suffix (2.0.5)
     puma (3.7.1)
     rack (2.0.1)
@@ -146,7 +144,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
@@ -168,13 +165,6 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.47.1)
-      parser (>= 2.3.3.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -199,7 +189,6 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.3)
     web-console (3.4.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -220,6 +209,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  friendly_id (~> 5.1.0)
   jbuilder (~> 2.5)
   jquery-rails
   launchy
@@ -230,7 +220,6 @@ DEPENDENCIES
   rails (~> 5.0.1)
   rails_12factor
   rspec-rails (~> 3.5)
-  rubocop (~> 0.47.1)
   sass-rails (~> 5.0)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,7 @@
 class CategoriesController < ApplicationController
 
   def show
-    @category = Category.find_by_param(params[:id])
+    @category = Category.friendly.find(params[:id])
   end
 
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,15 +2,7 @@ class Category < ApplicationRecord
   has_many :items
   validates_uniqueness_of :title
 
-  def to_param
-    title.downcase
-  end
+  extend FriendlyId
+  friendly_id :title, use: :slugged
 
-  def self.find_by_param(input)
-    find_by_title(input.capitalize)
-  end
-
-  def self.find(input)
-    input.to_i == 0 ? find_by_title(input) : super
-  end
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   #resources :categories, path: ''
   #^^^ this removes categories so url is just '/slammers' but causes a nil error
 
-  resources :categories, only: [:show] do
+  resources :categories, only: [:show], path: '' do
     resources :items, only: [:show]
   end
 
@@ -32,4 +32,6 @@ Rails.application.routes.draw do
   delete '/cart', to: 'carts#destroy'
 
   resources :orders, only: [:index, :show, :create]
+
+  # get '/categories/:id', to: 'categories#show', as: 'category'
 end

--- a/db/migrate/20170301223828_add_friendly_id_to_category.rb
+++ b/db/migrate/20170301223828_add_friendly_id_to_category.rb
@@ -1,0 +1,7 @@
+class AddFriendlyIdToCategory < ActiveRecord::Migration[5.0]
+  def change
+    add_column :categories, :slug, :string
+
+    add_index :categories, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,4 @@
- # This file is auto-generated from the current state of the database. Instead
+# This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228013938) do
+ActiveRecord::Schema.define(version: 20170301223828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 20170228013938) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "slug"
+    t.index ["slug"], name: "index_categories_on_slug", unique: true, using: :btree
   end
 
   create_table "items", force: :cascade do |t|


### PR DESCRIPTION
Fixes the "slug bug" to get rid of 'category' from a url for a category
-i deleted the logic for a slug in the category model and used the 'friendly id' gem
-a migration was made to add a slug to the categories table
-some syntax was added to the category show route to remove 'category' from the url
-You will have to run this: Category.find_each(&:save) in your rails c to update all your categories with the slugs